### PR TITLE
chore(Pixlike): refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Breaking
+- `pix!` macro now takes ints rather than strings for width and height
+- `TILESET` is now a `Tileset` struct with `tileset` and `tile_size` attributes
+- removed `tile_size` getter from `PixLike`
+
 ## [0.0.2] - 2017-07-09
 
 ### Breaking

--- a/pixset_derive/src/lib.rs
+++ b/pixset_derive/src/lib.rs
@@ -107,7 +107,7 @@ fn get_size_attr(attrs: &[syn::Attribute]) -> (u32, u32) {
 fn get_total_attr(attrs: &[syn::Attribute]) -> i32 {
     use syn::{Attribute, Ident, MetaItem};
 
-    let eg = "e.g. `#[size = \"16\"]`";
+    let eg = "e.g. `#[total = \"16\"]`";
 
     if let Some(attr) = attrs.iter().find(|attr| match attr.value {
         MetaItem::NameValue(ref ident, _) => *ident == Ident::from("total"),

--- a/pixset_derive/src/lib.rs
+++ b/pixset_derive/src/lib.rs
@@ -24,7 +24,6 @@ fn validate_input(ast: &syn::MacroInput) {
         panic!("Last Enum must be the variant `Empty`, please add it.");
     }
 
-    let _ = get_size_attr(&ast.attrs);
     let _ = get_total_attr(&ast.attrs);
 }
 
@@ -34,7 +33,6 @@ fn impl_pix(ast: &syn::MacroInput) -> quote::Tokens {
     let names_2 = iter::repeat(name);
     let variants = get_variants(ast);
     let variants_2 = get_variants(ast);
-    let size = get_size_attr(&ast.attrs);
     let coords = get_coords(variants.len(), get_total_attr(&ast.attrs));
 
     quote! {
@@ -50,10 +48,6 @@ fn impl_pix(ast: &syn::MacroInput) -> quote::Tokens {
                     #(#names_2::#variants_2 => #coords),*
                 }
             }
-
-            fn tile_size(&self) -> (u32, u32) {
-                #size
-            }
         }
 
         impl std::default::Default for #name {
@@ -61,46 +55,6 @@ fn impl_pix(ast: &syn::MacroInput) -> quote::Tokens {
                 #name::Empty
             }
         }
-    }
-}
-
-fn get_size_attr(attrs: &[syn::Attribute]) -> (u32, u32) {
-    use syn::{Ident, Lit, MetaItem, NestedMetaItem};
-
-    let eg = "e.g. `#[size(width = \"16\", height = \"24\")]`";
-
-    if let Some(size_attrs) = attrs.iter().find(|attr| match attr.value {
-        MetaItem::List(ref ident, _) => *ident == Ident::from("size"),
-        _ => false,
-    }) {
-        let get_attr = |name: &str, pos: usize| -> u32 {
-            if let MetaItem::List(_, ref vec) = size_attrs.value {
-                if let NestedMetaItem::MetaItem(
-                    MetaItem::NameValue(ref ident, Lit::Str(ref s, _)),
-                ) =
-                    *vec.get(pos)
-                        .unwrap_or_else(|| panic!("Must supply width and height {}", eg))
-                {
-                    if *ident != Ident::from(name) {
-                        panic!("Must supply {} as an attribute {}", name, eg);
-                    }
-                    s.parse::<u32>().unwrap_or_else(|_| {
-                        panic!(
-                            "Parsing to u32 failed on '{}'. Only stringed integers are supported",
-                            s
-                        )
-                    })
-                } else {
-                    unreachable!()
-                }
-            } else {
-                unreachable!()
-            }
-        };
-
-        (get_attr("width", 0), get_attr("height", 1))
-    } else {
-        panic!("Must supply a size attribute e.g. {}", eg)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ extern crate pixset_derive;
 
 mod pix;
 
-pub use pix::{Pix, PixLike, PixStr, TILESET};
+pub use pix::{Pix, PixLike, PixStr, Tileset, TILESET};
 
 #[cfg(test)]
 mod tests {

--- a/src/pix.rs
+++ b/src/pix.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 
 pub trait PixLike: Default + Sized + Copy + Clone + Debug {
     fn pix_order() -> Vec<Self>;
-    fn tile_size(&self) -> (u32, u32);
     fn get(&self) -> (f32, f32, f32, f32);
 }
 
@@ -17,10 +16,17 @@ macro_rules! pix {
      $($ch:expr => $e2:ident),+;) => {
         use std::str;
 
-        pub static TILESET: &'static [u8] = include_bytes!($ts);
+        pub struct Tileset {
+            pub tileset: &'static [u8],
+            pub tile_size: (u32, u32),
+        }
+
+        pub static TILESET: Tileset = Tileset {
+            tileset: include_bytes!($ts),
+            tile_size: ($w, $h),
+        };
 
         #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PixLike)]
-        #[size(width = $w, height = $h)]
         #[total = $t]
         pub enum Pix {
             $($e),+,
@@ -82,8 +88,8 @@ macro_rules! pix {
 
 pix! {
     tileset => "../assets/tileset.png";
-    width => "16";
-    height => "16";
+    width => 16;
+    height => 16;
     total => "100";
     A,
     B,


### PR DESCRIPTION
This fixes needing to pass `pixset::Pix::Empty` into `gltile` renderer. Now we can get the `tileset` and `tile_size` from `TILESET` directly.